### PR TITLE
Bootstrapping words

### DIFF
--- a/forth.py
+++ b/forth.py
@@ -28,6 +28,7 @@ def forth_eval(parsed_array):
               line_ptr += 1
             elif word == "bye":
                 print("Bye.")
+		global executing
                 executing = False
             elif word == "@":
               line_ptr += 1 # Force the pointer ahead so the variable isn't treated as code.

--- a/forth.py
+++ b/forth.py
@@ -82,7 +82,7 @@ def forth_eval(parsed_array):
                         forth_eval(parse(repeated_code))
                         loop_ctr += 1
               else:
-                while loop_ctr >= loop_total:
+                while loop_ctr > loop_total:
                         forth_eval(parse(repeated_code))
                         loop_ctr -= 1
             else:

--- a/forth.py
+++ b/forth.py
@@ -27,9 +27,9 @@ def forth_eval(parsed_array):
               word_dict[function_name] = code_str
               line_ptr += 1
             elif word == "bye":
-		print("Bye.")
-		executing = False
-	    elif word == "@":
+                print("Bye.")
+                executing = False
+            elif word == "@":
               line_ptr += 1 # Force the pointer ahead so the variable isn't treated as code.
               stack.append(variables[parsed_array[line_ptr]]) # Append the value of the variable.
             elif word == "!": # This is the "setter" command for the variable.

--- a/forth.py
+++ b/forth.py
@@ -77,9 +77,14 @@ def forth_eval(parsed_array):
                 line_ptr += 1
               loop_ctr = 0
               loop_total = stack.pop() - stack.pop()
-              while loop_ctr < loop_total:
-                forth_eval(parse(repeated_code))
-                loop_ctr += 1
+              if loop_total > 0:
+                while loop_ctr < loop_total:
+                        forth_eval(parse(repeated_code))
+                        loop_ctr += 1
+              else:
+                while loop_ctr >= loop_total:
+                        forth_eval(parse(repeated_code))
+                        loop_ctr -= 1
             else:
               print("Undefined Word at {}".format(word)) # This is the undef'd error message.
           else:

--- a/forth.py
+++ b/forth.py
@@ -28,7 +28,7 @@ def forth_eval(parsed_array):
               line_ptr += 1
             elif word == "bye":
                 print("Bye.")
-		global executing
+                global executing
                 executing = False
             elif word == "@":
               line_ptr += 1 # Force the pointer ahead so the variable isn't treated as code.

--- a/forth_words.py
+++ b/forth_words.py
@@ -7,4 +7,7 @@ variables = {
 word_dict = {
   'swap': '! swap-top ! swap-bottom @ swap-top @ swap-bottom', # swap. It works without variable definiton because of a quirk of !
   'dup': '! dup-value @ dup-value @ dup-value', # dup works on similar logic to above.
+  'negate': '-1 *',
+  '-': 'negate +',
+  '*': '! loop-top ! by-value 0 0 @ loop-top do @ by-value + loop',
 }

--- a/forth_words.py
+++ b/forth_words.py
@@ -7,7 +7,7 @@ variables = {
 word_dict = {
   'swap': '! swap-top ! swap-bottom @ swap-top @ swap-bottom', # swap. It works without variable definiton because of a quirk of !
   'dup': '! dup-value @ dup-value @ dup-value', # dup works on similar logic to above.
-  'negate': '-1 *',
+  'negate': '-1 swap *',
   '-': 'negate +',
   '*': '! loop-top ! by-value 0 0 @ loop-top do @ by-value + loop',
 }

--- a/primitives.py
+++ b/primitives.py
@@ -12,8 +12,6 @@ primitives = {
   '.s': stackshow, # Show the stack.
   '.': lambda: print(stack.pop()), # Print the top off the stack.
   '+': lambda: stack.append(stack.pop() + stack.pop()),
-  '-': lambda: stack.append(stack.pop() - stack.pop()),
-  '*': lambda: stack.append(stack.pop() * stack.pop()),
   '/': lambda: stack.append(stack.pop() / stack.pop()),
   '^': lambda: stack.append(stack.pop() ** stack.pop()),
   '=': lambda: forthcomp("=="),


### PR DESCRIPTION
I fixed stuff.
And rewrote * and - as bootstrapped words.
There is also negate now.
So that's nice.